### PR TITLE
Fixing module loading order

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -209,7 +209,7 @@ export default function ComponentFactory (
 
       let useModules = this.modules
       if (variantModules[variant]) {
-        useModules = useModules.concat(variantModules[variant])
+        useModules.unshift(variantModules[variant])
       }
 
       const p = useModules.map(async (modName) => {

--- a/lib/components.js
+++ b/lib/components.js
@@ -209,7 +209,7 @@ export default function ComponentFactory (
 
       let useModules = this.modules
       if (variantModules[variant]) {
-        useModules.unshift(variantModules[variant])
+        useModules.unshift(...variantModules[variant])
       }
 
       const p = useModules.map(async (modName) => {


### PR DESCRIPTION
For Highchart modules like [stock-tools](https://www.highcharts.com/docs/stock/stock-tools#!), 'indicators-all' needs to be loaded first

Without indicators-all coming first, if you have the below config, and change the visualisation to 'hollowcandlestick', next time you load the page the chart won't load

```html
<highstock :options="chartOptions" :modules="['drag-panes', 'annotations-advanced', 'price-indicator', 'full-screen', 'stock-tools', 'hollowcandlestick', 'heikinashi']" />
```