### PR TITLE
fix: cannot start Nuxt, __dirname is not defined

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -2,6 +2,7 @@ import { readdirSync } from 'fs'
 import { defineNuxtModule, addPlugin, addTemplate } from '@nuxt/kit'
 import { fileURLToPath } from 'node:url';
 /**
+
  * This will let us map aliases to highcharts modules
  * (vite will need this to statically analyze the imports)
  * i.e., it can't analyze import(`highcharts/modules/${modName}.js`)

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,5 +1,4 @@
 import { readdirSync } from 'fs'
-import { resolve } from 'path'
 import { defineNuxtModule, addPlugin, addTemplate } from '@nuxt/kit'
 import { fileURLToPath } from 'node:url';
 /**

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,7 +1,7 @@
 import { readdirSync } from 'fs'
 import { resolve } from 'path'
 import { defineNuxtModule, addPlugin, addTemplate } from '@nuxt/kit'
-
+import { fileURLToPath } from 'node:url';
 /**
  * This will let us map aliases to highcharts modules
  * (vite will need this to statically analyze the imports)
@@ -49,7 +49,7 @@ export default defineNuxtModule({
       'highcharts/indicators/indicators-all.src.js'
     ])
 
-    nuxt.options.build.transpile.push(__dirname)
+    nuxt.options.build.transpile.push(fileURLToPath(import.meta.url))
     nuxt.options.runtimeConfig.public.nuxtHighcharts = {
       pluginOptions: options,
       hcMods
@@ -65,13 +65,13 @@ export default defineNuxtModule({
     })
 
     addTemplate({
-      src: resolve(__dirname, 'components.js'),
+      src: fileURLToPath(new URL('./components.js', import.meta.url)),
       filename: 'nuxt-highcharts.components.js'
     })
 
     addPlugin({
       ssr: false,
-      src: resolve(__dirname, 'plugin.js')
+      src: fileURLToPath(new URL('./plugin.js', import.meta.url)),
     })
   }
 })

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,4 +1,5 @@
 import { readdirSync } from 'fs'
+import { resolve } from 'path'
 import { defineNuxtModule, addPlugin, addTemplate } from '@nuxt/kit'
 import { fileURLToPath } from 'node:url';
 /**


### PR DESCRIPTION
This fixes the error "cannot start Nuxt, __dirname is not defined" with Nuxt 3.4.2+Nitro 2.3.3. 

You may want to fix this in a better way, this fix does it for me though. 

See also: https://nuxt.com/docs/guide/concepts/esm#migration